### PR TITLE
Fix _ParseConnect()

### DIFF
--- a/lib/ppymilter/ppymilterbase.py
+++ b/lib/ppymilter/ppymilterbase.py
@@ -273,8 +273,8 @@ class PpyMilterDispatcher(object):
         cmd: The single character command code representing this command.
         hostname: The hostname that originated the connection to the MTA.
         family: Address family for connection (see sendmail libmilter/mfdef.h).
-        port: The network port if appropriate for the connection or None
-        address: Remote address of the connection (e.g. IP address) if available or None
+        port: The network port if appropriate for the connection or None.
+        address: Remote address of the connection (e.g. IP address) if available or None.
     """
     (hostname, data) = data.split('\0', 1)
     family = struct.unpack('c', data[0])[0]

--- a/lib/ppymilter/ppymilterbase.py
+++ b/lib/ppymilter/ppymilterbase.py
@@ -280,7 +280,7 @@ class PpyMilterDispatcher(object):
     family = struct.unpack('c', data[0])[0]
     if family in ('4','6'): # SMFIA_INET / SMFIA_INET6
         port = struct.unpack('!H', data[1:3])[0]
-        address = data[3:]
+        address,_ = data[3:].split('\0',1)
     else: # SMFIA_UNKNOWN / SMFIA_UNIX
         port = None
         address = None

--- a/lib/ppymilter/ppymilterbase.py
+++ b/lib/ppymilter/ppymilterbase.py
@@ -273,13 +273,17 @@ class PpyMilterDispatcher(object):
         cmd: The single character command code representing this command.
         hostname: The hostname that originated the connection to the MTA.
         family: Address family for connection (see sendmail libmilter/mfdef.h).
-        port: The network port if appropriate for the connection.
-        address: Remote address of the connection (e.g. IP address).
+        port: The network port if appropriate for the connection or None
+        address: Remote address of the connection (e.g. IP address) if available or None
     """
     (hostname, data) = data.split('\0', 1)
     family = struct.unpack('c', data[0])[0]
-    port = struct.unpack('!H', data[1:3])[0]
-    address = data[3:]
+    if family in ('4','6'): # SMFIA_INET / SMFIA_INET6
+        port = struct.unpack('!H', data[1:3])[0]
+        address = data[3:]
+    else: # SMFIA_UNKNOWN / SMFIA_UNIX
+        port = None
+        address = None
     return (cmd, hostname, family, port, address)
 
   def _ParseHelo(self, cmd, data):


### PR DESCRIPTION
_ParseConnect() crashes if the client connects through a unix domain socket or if the protocol is "unknown" which I've actually seen happening a few times.

> DEBUG:ppymilter:  <<< Clocalhost=00U
> ERROR:ppymilter:uncaptured python exception, closing channel <ppymilter.ppymilterserver.ConnectionHandler connected 127.0.0.1:57708 at 0x7ff4498f1998> (<class 'struct.error'>:unpack requires a string argument of length 2 [/usr/lib/python2.7/asyncore.py|read|83] [/usr/lib/python2.7/asyncore.py|handle_read_event|449] [/usr/lib/python2.7/asynchat.py|handle_read|147] [build/bdist.linux-x86_64/egg/ppymilter/ppymilterserver.py|read_milter_data|171] [build/bdist.linux-x86_64/egg/ppymilter/ppymilterbase.py|Dispatch|212] [build/bdist.linux-x86_64/egg/ppymilter/ppymilterbase.py|_ParseConnect|281])

This patch tries to handle all possible address family types from libmilter/mfdef.h
